### PR TITLE
upgrade guardrails to 0.6.6 and fix urllib3 required version

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -27,9 +27,9 @@ fsspec==2024.6.1
 googleapis-common-protos==1.63.2
 griffe==0.36.9
 grpcio==1.65.1
-guardrails-ai==0.5.0
+guardrails-ai==0.6.6
 guardrails-api==0.0.1
-guardrails-api-client==0.3.8
+guardrails-api-client==0.4.0a1
 gunicorn==22.0.0
 h11==0.14.0
 httpcore==1.0.5
@@ -103,7 +103,7 @@ typer==0.9.4
 types-python-dateutil==2.9.0.20240316
 typing_extensions==4.12.2
 uri-template==1.3.0
-urllib3==2.2.2
+urllib3==2.0.7
 webcolors==24.6.0
 Werkzeug==3.0.3
 wrapt==1.16.0


### PR DESCRIPTION
upgrade guardrails to 0.6.6 and fix urllib3 required version